### PR TITLE
Fixed reading of SBOOT variable for starting the miner at boot

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ fi
 # Should we start at boot?
 #
   echo -n "Should we start the miner at boot? [Y/n]"
-  read $SBOOT
+  read SBOOT
   if [ -z $SBOOT ]; then
    SBOOT="y"
   fi


### PR DESCRIPTION
Just started trying this out, thanks for creating it. I noticed the script was trying to enable the service to start at boot and found that there was a dollar sign that seemed like it shouldn't be there.